### PR TITLE
Add GitHub Skills activity (#6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -33,6 +33,12 @@ activities = {
         "max_participants": 20,
         "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
     },
+    "GitHub Skills": {
+        "description": "Hands-on coding and collaboration workshops with GitHub Skills",
+        "schedule": "Mondays and Wednesdays, 3:00 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
+    },
     "Gym Class": {
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",


### PR DESCRIPTION
## Summary
- add the new GitHub Skills activity to the in-memory activities catalog
- set schedule, capacity, and initial empty roster so students can register

## Testing
- not run (data-only change)
